### PR TITLE
added code for removal of nth node from end of linked list

### DIFF
--- a/remove_nth_node.c
+++ b/remove_nth_node.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+struct ListNode {
+    int val;
+    struct ListNode* next;
+};
+
+struct ListNode* removeNthFromEnd(struct ListNode* head, int n) {
+    struct ListNode* res = (struct ListNode*)malloc(sizeof(struct ListNode));
+    res->val = 0;
+    res->next = head;
+
+    struct ListNode* dummy = res;
+    struct ListNode* temp = head;
+
+    for (int i = 0; i < n; i++) {
+        temp = temp->next;
+    }
+
+    while (temp != NULL) {
+        temp = temp->next;
+        dummy = dummy->next;
+    }
+
+    struct ListNode* toDelete = dummy->next;
+    dummy->next = dummy->next->next;
+    free(toDelete);
+
+    struct ListNode* ans = res->next;
+    free(res);
+    return ans;
+}


### PR DESCRIPTION
Algorithm: Remove Nth Node from End of Linked List

Create a dummy node and make it point to the head of the linked list.
(This helps handle edge cases like removing the first node.)

Initialize two pointers:

first pointing to the actual head of the list

second pointing to the dummy node

Move the first pointer n steps ahead in the list.

Move both pointers one step at a time until the first pointer reaches the end (NULL).

At this point, the second pointer will be just before the node that needs to be removed.

Adjust links:

Change the next pointer of the second node to skip the target node (i.e., second->next = second->next->next).

Delete the target node from memory to avoid memory leaks.

Return the new head of the list (which will be dummy->next).